### PR TITLE
Fix Grouping Again

### DIFF
--- a/app/models/notice_fingerprinter.rb
+++ b/app/models/notice_fingerprinter.rb
@@ -26,7 +26,8 @@ class NoticeFingerprinter
     else
       material << backtrace.
         lines.
-        select { |line| line.with_indifferent_access["file"].to_s.start_with?("[PROJECT_ROOT]") }.
+        map { |line| line.with_indifferent_access["file"].to_s }.
+        select { |line| line.start_with?("[PROJECT_ROOT]") }.
         slice(0, backtrace_lines)
     end
 


### PR DESCRIPTION
The modified logic was selecting lines that started with the project
root. However, the line object looks like this

```
{
  "number"=>"148",
  "file"=>"[PROJECT_ROOT]/app/views/shared/_grid_block_item.html.erb",
  "method"=> "block in _app_views_shared__grid_block_item_html_erb___4054598342690822596_69862626568500"
}
```

The method part sometimes is dynamic / changes. When this is hashed is
causes the same "error" to spit out a different hash.

To fix just using the "file" part when computing the hash.
